### PR TITLE
Fix FEN layout for single empty squares.

### DIFF
--- a/memlayout.py
+++ b/memlayout.py
@@ -99,7 +99,7 @@ class Board():
             if y<self.height-1: b += "/"
             for x in range(self.width):
                 b+=self.getAtCase(x,y)
-        for i in range(8,1,-1):
+        for i in range(8,0,-1):
             b=b.replace(" "*i,str(i))
         return f"[{b}:{l}:{t}:{'w' if self.isBlacksMove else 'b'}]"
     def getAt(self,x,y):


### PR DESCRIPTION
The 'range' function's output includes the first argument but not the second, so in order to get single spaces to be denoted as '1', the range call needs to be range(8,0,-1) not range(8,1,-1).